### PR TITLE
Add CSV loaders and safety stock calculation

### DIFF
--- a/data_load.py
+++ b/data_load.py
@@ -1,0 +1,73 @@
+import pandas as pd
+from typing import Iterable
+
+from schemas import BankMaster, FeeRow, BalanceSnapshot, CashflowRow
+
+__all__ = [
+    "load_bank_master",
+    "load_fee_table",
+    "load_balance",
+    "load_cashflow",
+]
+
+
+def _validate_columns(df: pd.DataFrame, required: Iterable[str], path: str) -> None:
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns {missing} in {path}")
+
+
+def load_bank_master(path: str) -> pd.DataFrame:
+    """Load bank_master.csv enforcing column types."""
+    columns = list(BankMaster.__annotations__.keys())
+    dtype = {
+        "bank_id": str,
+        "branch_id": str,
+        "service_id": str,
+        "cut_off_time": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_fee_table(path: str) -> pd.DataFrame:
+    """Load fee_table.csv enforcing column types."""
+    columns = list(FeeRow.__annotations__.keys())
+    dtype = {
+        "from_bank": str,
+        "service_id": str,
+        "amount_bin": str,
+        "to_bank": str,
+        "to_branch": str,
+        "fee": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_balance(path: str) -> pd.DataFrame:
+    """Load balance_snapshot.csv enforcing column types."""
+    columns = list(BalanceSnapshot.__annotations__.keys())
+    dtype = {
+        "bank_id": str,
+        "balance": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_cashflow(path: str) -> pd.DataFrame:
+    """Load cashflow_history.csv enforcing column types."""
+    columns = list(CashflowRow.__annotations__.keys())
+    dtype = {
+        "date": str,
+        "bank_id": str,
+        "amount": "int64",
+        "direction": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,45 @@
+import math
+import pandas as pd
+from typing import Iterable
+
+__all__ = ["calc_safety"]
+
+
+def _validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns: {missing}")
+
+
+def calc_safety(
+    df_cash: pd.DataFrame, horizon_days: int = 30, quantile: float = 0.95
+) -> pd.Series:
+    """Calculate safety stock per bank.
+
+    Parameters
+    ----------
+    df_cash: DataFrame with columns date, bank_id, amount, direction
+    horizon_days: rolling window size in days
+    quantile: percentile of rolling net outflow
+    """
+    req = ["date", "bank_id", "amount", "direction"]
+    _validate_columns(df_cash, req)
+
+    df = df_cash.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    sign = df["direction"].map({"out": 1, "in": -1})
+    if sign.isna().any():
+        raise ValueError("direction must be 'in' or 'out'")
+    df["signed"] = df["amount"] * sign
+    df = df.sort_values(["bank_id", "date"])
+
+    rolled = (
+        df.set_index("date")
+        .groupby("bank_id")["signed"]
+        .rolling(f"{horizon_days}D")
+        .sum()
+    )
+
+    safety = rolled.groupby("bank_id").quantile(quantile).fillna(0)
+    # round up to integer safety stock
+    return safety.apply(lambda x: int(math.ceil(x)))

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- add typed CSV loader functions with column validation
- implement safety stock calculation using rolling net outflows

## Testing
- `python -m py_compile schemas.py data_load.py safety.py`


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c