### PR TITLE
Add data loaders and safety stock calculation

### DIFF
--- a/data_load.py
+++ b/data_load.py
@@ -1,0 +1,74 @@
+import pandas as pd
+from typing import List
+
+from schemas import BankMaster, FeeRow, BalanceSnapshot, CashflowRow
+
+__all__ = [
+    "load_bank_master",
+    "load_fee_table",
+    "load_balance",
+    "load_cashflow",
+]
+
+
+def _validate_columns(df: pd.DataFrame, required: List[str], path: str) -> None:
+    """Ensure DataFrame has all required columns."""
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns {missing} in {path}")
+
+
+def load_bank_master(path: str) -> pd.DataFrame:
+    """Load bank_master.csv enforcing column types."""
+    columns = list(BankMaster.__annotations__.keys())
+    dtype = {
+        "bank_id": str,
+        "branch_id": str,
+        "service_id": str,
+        "cut_off_time": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_fee_table(path: str) -> pd.DataFrame:
+    """Load fee_table.csv enforcing column types."""
+    columns = list(FeeRow.__annotations__.keys())
+    dtype = {
+        "from_bank": str,
+        "service_id": str,
+        "amount_bin": str,
+        "to_bank": str,
+        "to_branch": str,
+        "fee": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_balance(path: str) -> pd.DataFrame:
+    """Load balance_snapshot.csv enforcing column types."""
+    columns = list(BalanceSnapshot.__annotations__.keys())
+    dtype = {
+        "bank_id": str,
+        "balance": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_cashflow(path: str) -> pd.DataFrame:
+    """Load cashflow_history.csv enforcing column types."""
+    columns = list(CashflowRow.__annotations__.keys())
+    dtype = {
+        "date": str,
+        "bank_id": str,
+        "amount": "int64",
+        "direction": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from typing import Iterable
+
+__all__ = ["calc_safety"]
+
+
+_REQUIRED_COLS = {"date", "bank_id", "amount", "direction"}
+
+
+def _ensure_columns(df: pd.DataFrame) -> None:
+    missing = _REQUIRED_COLS - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing columns {sorted(missing)}")
+
+
+def _net_amount(row: pd.Series) -> int:
+    return row["amount"] if row["direction"] == "out" else -row["amount"]
+
+
+def calc_safety(df_cash: pd.DataFrame, horizon_days: int = 30, quantile: float = 0.95) -> pd.Series:
+    """Return required safety stock per bank as a Series of integers."""
+    _ensure_columns(df_cash)
+
+    df = df_cash.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df["net"] = df.apply(_net_amount, axis=1)
+
+    # Aggregate by bank and date to ensure daily frequency
+    daily = (
+        df.groupby(["bank_id", "date"], sort=True)["net"].sum().unstack("bank_id").sort_index()
+    )
+
+    # Reindex to daily frequency for each bank
+    daily = daily.asfreq("D", fill_value=0)
+
+    safety = {}
+    for bank in daily.columns:
+        rolling = daily[bank].rolling(horizon_days, min_periods=1).sum()
+        level = rolling.quantile(quantile)
+        safety[bank] = int(round(level))
+
+    return pd.Series(safety)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    """Schema for bank_master.csv rows."""
+
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    """Schema for fee_table.csv rows."""
+
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    """Schema for balance_snapshot.csv rows."""
+
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    """Schema for cashflow_history.csv rows."""
+
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- add CSV loading utilities with strict dtype enforcement
- implement safety stock calculation per bank
- document dataclass schemas

## Testing
- `python -m py_compile schemas.py data_load.py safety.py`


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c