### PR TITLE
Add CSV utilities and safety stock calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# agent
+# Agent Repository
+
+This repository provides helper utilities for loading bank-related CSV files and calculating required safety stock levels.
+
+- **schemas.py**: Defines dataclasses describing each CSV schema.
+- **data_load.py**: Functions to load each CSV with strict dtype enforcement and column validation.
+- **safety.py**: Implements `calc_safety` to compute safety stock based on rolling net outflows.

--- a/data_load.py
+++ b/data_load.py
@@ -1,0 +1,79 @@
+import pandas as pd
+from typing import List
+
+__all__ = [
+    "load_bank_master",
+    "load_fee_table",
+    "load_balance",
+    "load_cashflow",
+]
+
+
+def _validate_columns(df: pd.DataFrame, required: List[str], path: str) -> None:
+    """Ensure DataFrame has all required columns."""
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns {missing} in {path}")
+
+
+def load_bank_master(path: str) -> pd.DataFrame:
+    """Load bank_master.csv enforcing column types."""
+    columns = ["bank_id", "branch_id", "service_id", "cut_off_time"]
+    dtype = {
+        "bank_id": str,
+        "branch_id": str,
+        "service_id": str,
+        "cut_off_time": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_fee_table(path: str) -> pd.DataFrame:
+    """Load fee_table.csv enforcing column types."""
+    columns = [
+        "from_bank",
+        "service_id",
+        "amount_bin",
+        "to_bank",
+        "to_branch",
+        "fee",
+    ]
+    dtype = {
+        "from_bank": str,
+        "service_id": str,
+        "amount_bin": str,
+        "to_bank": str,
+        "to_branch": str,
+        "fee": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_balance(path: str) -> pd.DataFrame:
+    """Load balance_snapshot.csv enforcing column types."""
+    columns = ["bank_id", "balance"]
+    dtype = {
+        "bank_id": str,
+        "balance": "int64",
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]
+
+
+def load_cashflow(path: str) -> pd.DataFrame:
+    """Load cashflow_history.csv enforcing column types."""
+    columns = ["date", "bank_id", "amount", "direction"]
+    dtype = {
+        "date": str,
+        "bank_id": str,
+        "amount": "int64",
+        "direction": str,
+    }
+    df = pd.read_csv(path, dtype=dtype)
+    _validate_columns(df, columns, path)
+    return df[columns]

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+__all__ = ["calc_safety"]
+
+
+def calc_safety(df_cash: pd.DataFrame, horizon_days: int = 30, quantile: float = 0.95) -> pd.Series:
+    """Return required safety stock per bank using rolling net outflow quantiles."""
+    required_cols = {"date", "bank_id", "amount", "direction"}
+    if not required_cols.issubset(df_cash.columns):
+        missing = required_cols - set(df_cash.columns)
+        raise ValueError(f"Missing columns {missing}")
+
+    df = df_cash.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df = df.sort_values(["bank_id", "date"])
+
+    direction_map = {"out": 1, "in": -1}
+    if not set(df["direction"]).issubset(direction_map.keys()):
+        raise ValueError("direction column must contain only 'in' or 'out'")
+    df["net"] = df["amount"] * df["direction"].map(direction_map)
+
+    window = f"{horizon_days}D"
+    rolling = (
+        df.set_index("date")
+        .groupby("bank_id")["net"]
+        .rolling(window, min_periods=1)
+        .sum()
+        .reset_index()
+    )
+
+    quant = rolling.groupby("bank_id")["net"].quantile(quantile)
+
+    return quant.round().astype(int)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- document dataclasses for CSV schemas
- add CSV loading helpers with column validation
- implement safety stock calculation using rolling net outflows

## Testing
- `python -m py_compile schemas.py data_load.py safety.py`


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c