### PR TITLE
Add calc_safety utility

### DIFF
--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+
+
+def calc_safety(df_cash: pd.DataFrame, horizon_days: int = 30, quantile: float = 0.95) -> pd.Series:
+    """Return required safety stock per bank using rolling net outflow.
+
+    Parameters
+    ----------
+    df_cash : pd.DataFrame
+        Must contain columns ["date", "bank_id", "amount", "direction"].
+    horizon_days : int, default 30
+        Rolling window size in days.
+    quantile : float, default 0.95
+        Quantile to compute from rolling net outflows.
+    """
+    if not {"date", "bank_id", "amount", "direction"}.issubset(df_cash.columns):
+        raise ValueError("df_cash missing required columns")
+
+    df = df_cash.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    # outflow as positive, inflow as negative
+    df["net"] = np.where(df["direction"] == "out", df["amount"], -df["amount"])
+    df = df.sort_values(["bank_id", "date"])
+
+    def calc_quantile(group: pd.DataFrame) -> float:
+        net_roll = (
+            group.set_index("date")["net"].rolling(f"{horizon_days}D").sum()
+        )
+        q = net_roll.quantile(quantile)
+        return max(float(q), 0.0)
+
+    safety = df.groupby("bank_id").apply(calc_quantile)
+    return safety.astype(int)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- define dataclasses for the CSV schemas
- add `calc_safety` to compute safety stock per bank using rolling net outflows

## Testing
- `python -m py_compile schemas.py safety.py`

------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c