### PR TITLE
Add transfer plan CSV export helper

### DIFF
--- a/export.py
+++ b/export.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from typing import Iterable, Mapping
+
+__all__ = ["to_csv"]
+
+def to_csv(plan: Iterable[Mapping], path: str) -> None:
+    """Export transfer plan to CSV.
+
+    Parameters
+    ----------
+    plan : Iterable[Mapping]
+        Iterable of transfer plan records. Each record should provide
+        execute_date, from_bank, to_bank, service_id, amount, and
+        expected_fee fields.
+    path : str
+        Destination CSV file path.
+    """
+    columns = [
+        "execute_date",
+        "from_bank",
+        "to_bank",
+        "service_id",
+        "amount",
+        "expected_fee",
+    ]
+
+    df = pd.DataFrame(list(plan))
+    missing = [c for c in columns if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns {missing} in plan")
+
+    df = df[columns]
+    df.to_csv(path, index=False)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- implement `to_csv` in `export.py` to save transfer plans

## Testing
- `python -m py_compile schemas.py export.py`


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c