### PR TITLE
Add cost comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # agent
+
+This repository defines CSV schemas using Python dataclasses and provides utilities.
+
+## Modules
+
+- `schemas.py` -- dataclass definitions for the CSV files.
+- `charts.py` -- contains `plot_cost_comparison` that creates a stacked bar chart comparing baseline and optimised cost and saves it to `/output/cost_comparison.png`.
+

--- a/charts.py
+++ b/charts.py
@@ -1,0 +1,23 @@
+import os
+import matplotlib.pyplot as plt
+
+__all__ = ["plot_cost_comparison"]
+
+def plot_cost_comparison(baseline_cost: float, optimised_cost: float, output_path: str = "/output/cost_comparison.png") -> None:
+    """Plot stacked bar chart comparing baseline and optimised cost."""
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(4, 6))
+
+    # Single stacked bar
+    ax.bar(["Cost"], [baseline_cost], label="Baseline")
+    ax.bar(["Cost"], [optimised_cost], bottom=[baseline_cost], label="Optimised")
+
+    ax.set_ylabel("Cost")
+    ax.legend()
+
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- define `plot_cost_comparison` in `charts.py`
- document chart module in README

## Testing
- `python -m py_compile schemas.py charts.py`


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c