### PR TITLE
Add interactive notebook and fix schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# agent
+# Agent Repository
+
+This project provides helper utilities for handling bank transaction CSV files.
+
+Available modules:
+- `schemas.py`: dataclass schemas for each CSV file.
+- `interactive_notebook.ipynb`: Jupyter notebook with sliders to run an optimisation example.

--- a/interactive_notebook.ipynb
+++ b/interactive_notebook.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive Optimisation Notebook\n",
+    "\n",
+    "Use the sliders to tune parameters and run the optimisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# path placeholders\n",
+    "bank_master_path = 'bank_master.csv'\n",
+    "fee_table_path = 'fee_table.csv'\n",
+    "balance_path = 'balance_snapshot.csv'\n",
+    "cashflow_path = 'cashflow_history.csv'\n",
+    "\n",
+    "def load_data():\n",
+    "    df_bank = pd.read_csv(bank_master_path)\n",
+    "    df_fee = pd.read_csv(fee_table_path)\n",
+    "    df_bal = pd.read_csv(balance_path)\n",
+    "    df_cash = pd.read_csv(cashflow_path)\n",
+    "    return df_bank, df_fee, df_bal, df_cash\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def calc_safety(df_cash, horizon_days=30, quantile=0.95):\n",
+    "    df = df_cash.copy()\n",
+    "    df['date'] = pd.to_datetime(df['date'])\n",
+    "    df['net'] = df.apply(lambda r: r.amount if r.direction=='out' else -r.amount, axis=1)\n",
+    "    roll = (\n",
+    "        df.set_index('date').groupby('bank_id')['net']\n",
+    "        .rolling(f\"{horizon_days}D\").sum().reset_index()\n",
+    "    )\n",
+    "    q = roll.groupby('bank_id')['net'].quantile(quantile)\n",
+    "    return q.round().astype(int)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def optimise_plan(df_bank, df_fee, df_bal, df_cash, lam):\n",
+    "    # placeholder optimisation - return empty dataframe\n",
+    "    return pd.DataFrame(columns=['execute_date', 'from_bank', 'to_bank', 'service_id', 'amount', 'expected_fee'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "h_slider = widgets.IntSlider(value=30, min=7, max=60, description=\"horizon\")\n",
+    "q_slider = widgets.FloatSlider(value=0.95, min=0.5, max=0.99, step=0.01, description=\"quantile\")\n",
+    "lambda_slider = widgets.FloatSlider(value=1.0, min=0, max=5, step=0.1, description=\"lambda\")\n",
+    "run_button = widgets.Button(description=\"Run optimisation\")\n",
+    "out = widgets.Output()\n",
+    "\n",
+    "def on_run_clicked(b):\n",
+    "    out.clear_output()\n",
+    "    df_bank, df_fee, df_bal, df_cash = load_data()\n",
+    "    safety = calc_safety(df_cash, h_slider.value, q_slider.value)\n",
+    "    plan = optimise_plan(df_bank, df_fee, df_bal, df_cash, lambda_slider.value)\n",
+    "    with out:\n",
+    "        display(safety)\n",
+    "        display(plan)\n",
+    "        plan.to_csv(\"transfer_plan.csv\", index=False)\n",
+    "        print(\"Saved transfer_plan.csv\")\n",
+    "run_button.on_click(on_run_clicked)\n",
+    "display(h_slider, q_slider, lambda_slider, run_button, out)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out


### PR DESCRIPTION
## Summary
- restore clean dataclasses for CSV schemas
- document modules in README
- add Jupyter notebook `interactive_notebook.ipynb` demonstrating optimisation controls with ipywidgets

## Testing
- `python -m py_compile schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c