### PR TITLE
Add safety calculation and fee lookup with tests

### DIFF
--- a/fee.py
+++ b/fee.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+__all__ = ["FeeCalculator"]
+
+class FeeCalculator:
+    """Lookup transaction fees from a fee table DataFrame."""
+
+    def __init__(self, df_fee: pd.DataFrame) -> None:
+        self.df = df_fee.copy()
+
+    def _parse_bin(self, bin_str: str) -> tuple:
+        """Return lower and upper bounds for an amount_bin string."""
+        if bin_str.endswith('+'):
+            lower = int(bin_str[:-1])
+            return lower, float('inf')
+        if '-' in bin_str:
+            lower, upper = bin_str.split('-', 1)
+            return int(lower), int(upper)
+        raise ValueError(f"Invalid amount_bin {bin_str}")
+
+    def get_fee(
+        self,
+        from_bank: str,
+        service_id: str,
+        amount: int,
+        to_bank: str,
+        to_branch: str,
+    ) -> int:
+        """Return fee for a transaction."""
+        df_match = self.df[
+            (self.df["from_bank"] == from_bank)
+            & (self.df["service_id"] == service_id)
+            & (self.df["to_bank"] == to_bank)
+            & (self.df["to_branch"] == to_branch)
+        ]
+        for _, row in df_match.iterrows():
+            lower, upper = self._parse_bin(row["amount_bin"])
+            if lower <= amount < upper:
+                return int(row["fee"])
+        raise ValueError("No fee found for given parameters")

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+__all__ = ["calc_safety"]
+
+def calc_safety(df_cash: pd.DataFrame, horizon_days: int = 30, quantile: float = 0.95) -> pd.Series:
+    """Return required safety stock per bank.
+
+    Parameters
+    ----------
+    df_cash : pd.DataFrame
+        DataFrame with columns ['date', 'bank_id', 'amount', 'direction']
+    horizon_days : int, default 30
+        Rolling window size in days.
+    quantile : float, default 0.95
+        Quantile to compute from rolling net outflows.
+    """
+    required_cols = {"date", "bank_id", "amount", "direction"}
+    if not required_cols.issubset(df_cash.columns):
+        missing = required_cols - set(df_cash.columns)
+        raise ValueError(f"Missing columns {missing}")
+
+    df = df_cash.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df = df.sort_values(["bank_id", "date"])
+
+    direction_map = {"out": 1, "in": -1}
+    if not set(df["direction"]).issubset(direction_map.keys()):
+        raise ValueError("direction column must contain only 'in' or 'out'")
+
+    df["net"] = df["amount"] * df["direction"].map(direction_map)
+
+    window = f"{horizon_days}D"
+    rolling = (
+        df.set_index("date")
+        .groupby("bank_id")["net"]
+        .rolling(window, min_periods=1)
+        .sum()
+        .reset_index()
+    )
+
+    quant = rolling.groupby("bank_id")["net"].quantile(quantile)
+
+    # Safety stock cannot be negative
+    quant = quant.clip(lower=0)
+
+    return quant.round().astype(int)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BankMaster",
+    "FeeRow",
+    "BalanceSnapshot",
+    "CashflowRow",
+]
+
+@dataclass
+class BankMaster:
+    bank_id: str
+    branch_id: str
+    service_id: str
+    cut_off_time: str  # HH:MM
+
+
+@dataclass
+class FeeRow:
+    from_bank: str
+    service_id: str
+    amount_bin: str
+    to_bank: str
+    to_branch: str
+    fee: int
+
+
+@dataclass
+class BalanceSnapshot:
+    bank_id: str
+    balance: int
+
+
+@dataclass
+class CashflowRow:
+    date: str  # YYYY-MM-DD
+    bank_id: str
+    amount: int
+    direction: str  # in|out

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from fee import FeeCalculator
+from safety import calc_safety
+
+
+def test_calc_safety_zero_flows():
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "bank_id": ["A", "A"],
+        "amount": [0, 0],
+        "direction": ["out", "in"],
+    })
+    result = calc_safety(df, horizon_days=2, quantile=0.95)
+    assert result.loc["A"] == 0
+
+
+def test_calc_safety_all_inflows():
+    df = pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "bank_id": ["A", "A"],
+        "amount": [100, 200],
+        "direction": ["in", "in"],
+    })
+    result = calc_safety(df, horizon_days=2, quantile=0.95)
+    assert result.loc["A"] == 0
+
+
+def test_fee_calculator_bin_selection():
+    df_fee = pd.DataFrame({
+        "from_bank": ["A", "A"],
+        "service_id": ["S", "S"],
+        "amount_bin": ["0-100", "100+"],
+        "to_bank": ["B", "B"],
+        "to_branch": ["X", "X"],
+        "fee": [10, 20],
+    })
+    calc = FeeCalculator(df_fee)
+    assert calc.get_fee("A", "S", 50, "B", "X") == 10
+    assert calc.get_fee("A", "S", 100, "B", "X") == 20
+    assert calc.get_fee("A", "S", 150, "B", "X") == 20


### PR DESCRIPTION
## Summary
- implement `calc_safety` in `safety.py` to compute rolling net outflow quantiles
- implement `FeeCalculator` in `fee.py` for fee lookup by amount bin
- add pytest suite covering safety stock edge cases and fee bin selection

## Testing
- `python -m py_compile schemas.py safety.py fee.py tests/test_functions.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6836c18d97e883329bb8d9da9c0e431c